### PR TITLE
support downloading videos with MPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Large-scale text-video dataset, **containing 10 million video-text pairs** scrap
 ## Download videos
 
 1. Download csv file(s) above to this repository
-2. `pip install pandas numpy requests`
+2. `pip install pandas numpy requests mpi4py`
 3. To download on one job: `python download.py --csv_path results_2M_train.csv --partitions 1 --part 0 --data_dir ./data --processes 8`. You can split this across N concurrent jobs by choosing `--partitions N` partitions and running each job with different `--part $idx`. You can also specify the number of processes, recommended one per cpu.
 
 There might be more efficient ways download the videos than this script, e.g. by modifying https://github.com/rom1504/img2dataset to download videos instead of images.

--- a/download.py
+++ b/download.py
@@ -4,7 +4,11 @@ import numpy as np
 import argparse
 import requests
 import concurrent.futures
+from mpi4py import MPI
 
+COMM = MPI.COMM_WORLD
+RANK = COMM.Get_rank()
+SIZE = COMM.Get_size()
 
 def request_save(url, save_fp):
     img_data = requests.get(url, timeout=5).content
@@ -15,11 +19,15 @@ def request_save(url, save_fp):
 def main(args):
     ### preproc
     video_dir = os.path.join(args.data_dir, 'videos')
-    if not os.path.exists(os.path.join(video_dir, 'videos')):
-        os.makedirs(os.path.join(video_dir, 'videos'))
+    if RANK == 0:
+        if not os.path.exists(os.path.join(video_dir, 'videos')):
+            os.makedirs(os.path.join(video_dir, 'videos'))
+    
+    COMM.barrier()
 
     # ASSUMES THE CSV FILE HAS BEEN SPLIT INTO N PARTS
     partition_dir = args.csv_path.replace('.csv', f'_{args.partitions}')
+
     # if not, then split in this job.
     if not os.path.exists(partition_dir):
         os.makedirs(partition_dir)
@@ -42,7 +50,8 @@ def main(args):
 
 
     df = pd.read_csv(os.path.join(partition_dir, f'{args.part}.csv'))
-    df['rel_fn'] = df.apply(lambda x: os.path.join(x['page_dir'], str(x['videoid'])),
+
+    df['rel_fn'] = df.apply(lambda x: os.path.join(str(x['page_dir']), str(x['videoid'])),
                             axis=1)
 
     df['rel_fn'] = df['rel_fn'] + '.mp4'
@@ -88,6 +97,9 @@ if __name__ == "__main__":
                         help='Path to csv data to download')
     parser.add_argument('--processes', type=int, default=8)
     args = parser.parse_args()
+
+    if SIZE > 1:
+        args.part = RANK
 
     if args.part >= args.partitions:
         raise ValueError("Part idx must be less than number of partitions")

--- a/download.py
+++ b/download.py
@@ -5,6 +5,7 @@ import argparse
 import requests
 import concurrent.futures
 from mpi4py import MPI
+import warnings 
 
 COMM = MPI.COMM_WORLD
 RANK = COMM.Get_rank()
@@ -99,6 +100,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if SIZE > 1:
+        warnings.warn("Overriding --part with MPI rank number")
         args.part = RANK
 
     if args.part >= args.partitions:


### PR DESCRIPTION
For step 3:

To download on one job: `python download.py --csv_path results_2M_train.csv --partitions 1 --part 0 --data_dir ./data --processes 8`. You can split this across N concurrent jobs by choosing `--partitions N` partitions and running each job with different `--part $idx`. You can also specify the number of processes, recommended one per cpu.

users can use MPI to spawn multiple processes, with each process id equaling the partition ID rather than manually setting the partition id. That may be useful
